### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -19,7 +19,7 @@
         <dependency org="commons-lang" name="commons-lang" rev="2.5"/>
         <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1"/>
         <dependency org="commons-io" name="commons-io" rev="2.4"/>
-        <dependency org="commons-collections" name="commons-collections" rev="3.2.1"/>
+        <dependency org="commons-collections" name="commons-collections" rev="3.2.2"/>
         <dependency org="com.google.code.gson" name="gson" rev="2.2.4"/>
 		<dependency org="com.google.guava" name="guava" rev="15.0"/>
 	    <dependency org="com.google.appengine" name="appengine-api-1.0-sdk" rev="1.7.3"/>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
